### PR TITLE
Switch from broken autodefer to manual defer

### DIFF
--- a/DanMemoDiscordBot/app.py
+++ b/DanMemoDiscordBot/app.py
@@ -73,8 +73,10 @@ async def on_start():
         )
     ],
 )
-@interactions.autodefer()  # to tell Discord that commands may take longer than the default 3s timeout
 async def sacalc(ctx: CommandContext, config: Optional[interactions.Attachment] = None):
+    # to tell Discord this command may take longer than the default 3s timeout
+    # Used because autodefer() doesn't work: https://github.com/interactions-py/interactions.py/issues/1021
+    await ctx.defer()
     await command_saCalculator.run(client, ctx, config)
 
 
@@ -90,11 +92,12 @@ async def sacalc(ctx: CommandContext, config: Optional[interactions.Attachment] 
         )
     ],
 )
-@interactions.autodefer()
 async def rbcalc(ctx: CommandContext, config: Optional[interactions.Attachment] = None):
     # imanity server only and ex-imanity role
     # if(await hasAccess(ctx.message.author,EDITORS) or ctx.message.author.guild.id == 685046495988154373):
     try:
+        # to tell Discord this command may take longer than the default 3s timeout
+        await ctx.defer()
         await command_rbCalc.run(client, ctx, config)
     except:
         tb = traceback.format_exc()
@@ -113,8 +116,9 @@ async def rbcalc(ctx: CommandContext, config: Optional[interactions.Attachment] 
         )
     ],
 )
-@interactions.autodefer()
 async def characterSearch(ctx: CommandContext, keywords: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_commonSearch.run(
         dbConfig, client, ctx, keywords, is_character_search=True
     )
@@ -132,8 +136,9 @@ async def characterSearch(ctx: CommandContext, keywords: str):
         )
     ],
 )
-@interactions.autodefer()
 async def skillSearch(ctx: CommandContext, keywords: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_commonSearch.run(
         dbConfig, client, ctx, keywords, is_character_search=False
     )
@@ -157,8 +162,9 @@ async def skillSearch(ctx: CommandContext, keywords: str):
         ),
     ],
 )
-@interactions.autodefer()
 async def help(ctx: CommandContext, sub_command: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_help.run(ctx, sub_command)
 
 
@@ -166,8 +172,9 @@ async def help(ctx: CommandContext, sub_command: str):
     name="invite",
     description="Prints the server invite link for the bot",
 )
-@interactions.autodefer()
 async def invite(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_invite.run(ctx)
 
 
@@ -175,8 +182,9 @@ async def invite(ctx: CommandContext):
     name="support",
     description="Sends a link to our support server. Please contact Eric#5731 or Yon#7436",
 )
-@interactions.autodefer()
 async def support(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_support.run(ctx)
 
 
@@ -184,8 +192,9 @@ async def support(ctx: CommandContext):
     name="popularity",
     description="Displays current Ais bot popularity",
 )
-@interactions.autodefer()
 async def popularity(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_popularity.run(client, ctx)
 
 
@@ -193,8 +202,9 @@ async def popularity(ctx: CommandContext):
     name="bento",
     description="Syr's lunch box! Get crepes every two hours that can be traded for gacha rolls!",
 )
-@interactions.autodefer()
 async def bento(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_bento.run(dbConfig, ctx)
 
 
@@ -202,8 +212,9 @@ async def bento(ctx: CommandContext):
     name="gacha",
     description="Trade a crepe for an 11-draw gacha pull. In-game gacha rates. Limited and JP-only units are included",
 )
-@interactions.autodefer()
 async def gacha(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_gacha.run(dbConfig, ctx)
 
 
@@ -225,8 +236,9 @@ async def gacha(ctx: CommandContext):
         ),
     ],
 )
-@interactions.autodefer()
 async def gachamode(ctx: CommandContext, sub_command: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_gachaMode.run(dbConfig, ctx, sub_command)
 
 
@@ -248,8 +260,9 @@ async def gachamode(ctx: CommandContext, sub_command: str):
         ),
     ],
 )
-@interactions.autodefer()
 async def profile(ctx: CommandContext, sub_command: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_profile.run(dbConfig, client, ctx, sub_command)
 
 
@@ -271,8 +284,9 @@ async def profile(ctx: CommandContext, sub_command: str):
         ),
     ],
 )
-@interactions.autodefer()
 async def topUsers(ctx: CommandContext, sub_command: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_topUsers.run(dbConfig, client, ctx, sub_command)
 
 
@@ -288,8 +302,9 @@ async def topUsers(ctx: CommandContext, sub_command: str):
         )
     ],
 )
-@interactions.autodefer()
 async def dispatch(ctx: CommandContext, keywords: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_dispatch.run(dbConfig, ctx, keywords)
 
 
@@ -321,10 +336,11 @@ unit_attachment = interactions.Option(
         ),
     ],
 )
-@interactions.autodefer()
 async def addUpdateUnit(
     ctx: CommandContext, sub_command: str, unit_file: interactions.Attachment
 ):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_addUpdateUnit.run(dbConfig, client, ctx, sub_command, unit_file)
     # refresh the cache
     cache = Cache(dbConfig)
@@ -337,8 +353,9 @@ async def addUpdateUnit(
     scope=GUILD_ID,  # so the command is only visible & available on the dev server
     default_scope=False,
 )
-@interactions.autodefer()
 async def getJson(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_getJson.run(ctx)
 
 
@@ -348,8 +365,9 @@ async def getJson(ctx: CommandContext):
     scope=GUILD_ID,  # so the command is only visible & available on the dev server
     default_scope=False,
 )
-@interactions.autodefer()
 async def init(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_init.run(ctx)
 
 
@@ -383,8 +401,9 @@ killer_subcommands = [
     description="Posts infographic of all killer units in the game. Can also filter to one monster type.",
     options=killer_subcommands,
 )
-@interactions.autodefer()
 async def killer(ctx, sub_command: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_killer.run(ctx, dbConfig, sub_command)
 
 
@@ -392,8 +411,9 @@ async def killer(ctx, sub_command: str):
     name="elemental-assists",
     description="Posts an infographic of all elemental damage buffing/elemental resist debuffing assists in the game",
 )
-@interactions.autodefer()
 async def elementAssists(ctx: CommandContext):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_elementAssists.run(ctx, dbConfig)
 
 
@@ -423,8 +443,9 @@ async def elementAssists(ctx: CommandContext):
         ),
     ],
 )
-@interactions.autodefer()
 async def rb(ctx: CommandContext, sub_command: str):
+    # to tell Discord this command may take longer than the default 3s timeout
+    await ctx.defer()
     await command_rb.run(client, ctx, sub_command)
 
 


### PR DESCRIPTION
`interactions.autodefer()` currently has a bug (https://github.com/interactions-py/interactions.py/issues/1021) which completely kills the interaction as soon as the defer is triggered after 2 seconds. 

Manually defer all commands instead to avoid this problem.