### PR TITLE
Improve Unit JSON handling

### DIFF
--- a/DanMemoDiscordBot/app.py
+++ b/DanMemoDiscordBot/app.py
@@ -308,14 +308,6 @@ async def dispatch(ctx: CommandContext, keywords: str):
     await command_dispatch.run(dbConfig, ctx, keywords)
 
 
-unit_attachment = interactions.Option(
-    name="unit_file",
-    description="File containing the unit data in JSON format",
-    type=interactions.OptionType.ATTACHMENT,
-    required=True,
-)
-
-
 @client.command(
     name="add-update-unit",
     description="Adds a unit or overwrites an existing one",
@@ -323,25 +315,17 @@ unit_attachment = interactions.Option(
     default_scope=False,
     options=[
         interactions.Option(
-            name="adventurer",
-            description="Add an adventurer unit",
-            type=interactions.OptionType.SUB_COMMAND,
-            options=[unit_attachment],
-        ),
-        interactions.Option(
-            name="assist",
-            description="Add an assist unit",
-            type=interactions.OptionType.SUB_COMMAND,
-            options=[unit_attachment],
-        ),
+            name="unit_file",
+            description="File containing the unit data in JSON format",
+            type=interactions.OptionType.ATTACHMENT,
+            required=True,
+        )
     ],
 )
-async def addUpdateUnit(
-    ctx: CommandContext, sub_command: str, unit_file: interactions.Attachment
-):
+async def addUpdateUnit(ctx: CommandContext, unit_file: interactions.Attachment):
     # to tell Discord this command may take longer than the default 3s timeout
     await ctx.defer()
-    await command_addUpdateUnit.run(dbConfig, client, ctx, sub_command, unit_file)
+    await command_addUpdateUnit.run(dbConfig, client, ctx, unit_file)
     # refresh the cache
     cache = Cache(dbConfig)
     cache.refreshcache(dbConfig)

--- a/DanMemoDiscordBot/commands/getJson.py
+++ b/DanMemoDiscordBot/commands/getJson.py
@@ -240,7 +240,15 @@ def set_skill_effects(effects: list, is_assist: bool) -> List[dict]:
 
         curr_effects_list.append(curr_effects_dict)
 
-    return curr_effects_list
+    # Custom comparator, makes sure that damaging effects and their associated effects come first
+    def comparator(effects):
+        if effects.get("type") in ["physical_attack", "magic_attack"]:
+            return 0
+        if effects.get("target") == "skill":
+            return 1
+        return 2
+
+    return sorted(curr_effects_list, key=comparator)
 
 
 def zipdir(path: str, ziph: zipfile.ZipFile):


### PR DESCRIPTION
1. Unify add-update-unit commands for adventurer/assist
    Automatically infer unit type and add some additional sanity checks for the structure of the JSON file
2. Sort skill effects in get-json command output
     This aims to make the get-json output more consistent with the order of skills seen in-game and displayed by the character-search command