### PR TITLE
Fix various issues in Recordbuster calculator

### DIFF
--- a/DanMemoDiscordBot/commands/calculatorUtil.py
+++ b/DanMemoDiscordBot/commands/calculatorUtil.py
@@ -664,6 +664,23 @@ def Counters(notIn=[0,0,0,0]):
  """
 
 
+def interpretExtraBoostWrapper(
+    skillEffect, adventurer: "Adventurer", enemy: "Enemy"
+) -> float:
+    # This wrapper is used to make "per each regen" type skills be interpreted
+    # as both a "per each hp regen" and "per each mp regen" effect
+
+    temp_list = skillEffect.attribute.split("_")
+    if "regen" in temp_list and not "hp" in temp_list and not "mp" in temp_list:
+        skillEffect.attribute = skillEffect.attribute.replace("regen", "hp_regen")
+        extra_boosts_multiplier = interpretExtraBoost(skillEffect, adventurer, enemy)
+        skillEffect.attribute = skillEffect.attribute.replace("hp_regen", "mp_regen")
+        extra_boosts_multiplier += interpretExtraBoost(skillEffect, adventurer, enemy)
+    else:
+        extra_boosts_multiplier = interpretExtraBoost(skillEffect, adventurer, enemy)
+    return extra_boosts_multiplier
+
+
 def interpretExtraBoost(skillEffect, adventurer: "Adventurer", enemy: "Enemy") -> float:
     """(adventurerSkillEffect) -> float
     takes in a skill effect with attribute exists of "per_each" then parse it and return the extra boosts multiplier
@@ -775,7 +792,9 @@ def interpretSkillAdventurerAttack(
         # for example str/mag debuff
         if len(extra_boosts_effects) > 0:
             for extra_boosts in extra_boosts_effects:
-                temp_extra_boosts = interpretExtraBoost(extra_boosts, adventurer, enemy)
+                temp_extra_boosts = interpretExtraBoostWrapper(
+                    extra_boosts, adventurer, enemy
+                )
                 extra_boosts_value = extra_boosts_value + temp_extra_boosts
         # SELECT ase.AdventurerSkillEffectsid, ase.AdventurerSkillid, ase.duration, e.name AS element, m.value AS modifier, ty.name AS type, ta.name AS target, a.name AS attribute, s.name AS speed, ad.stars, ad.title, ad.alias, ad.limited, c.name
         ret = AdventurerSkill(
@@ -1295,7 +1314,7 @@ def counter(
         temp_adv_counter = adv.adventurerCounter
         temp_extra_boost = 1.0
         if adv.adventurerCounter.extraBoost != None:
-            temp_extra_boost_value = interpretExtraBoost(
+            temp_extra_boost_value = interpretExtraBoostWrapper(
                 adv.adventurerCounter.extraBoost, adv, enemy
             )
             temp_extra_boost += temp_extra_boost_value
@@ -1342,7 +1361,7 @@ def counters(
         temp_adv_counter = adv.adventurerCounter
         temp_extra_boost = 1.0
         if adv.adventurerCounter.extraBoost != None:
-            temp_extra_boost_value = interpretExtraBoost(
+            temp_extra_boost_value = interpretExtraBoostWrapper(
                 adv.adventurerCounter.extraBoost, adv, enemy
             )
             temp_extra_boost += temp_extra_boost_value

--- a/DanMemoDiscordBot/commands/calculatorUtil.py
+++ b/DanMemoDiscordBot/commands/calculatorUtil.py
@@ -971,7 +971,7 @@ def interpretSkillAdventurerEffects(
         elif "removal_no_assist" in curr_attribute:
             is_buff = not ("debuff" in curr_attribute)
 
-            temp_list = curr_attribute.replace("removal_no_assist", "").split("_")
+            temp_list = curr_attribute.replace("_removal_no_assist", "").split("_")
             try:
                 temp_list.remove("buff")
             except:
@@ -980,7 +980,7 @@ def interpretSkillAdventurerEffects(
                 temp_list.remove("debuff")
             except:
                 pass
-            temp_attribute = " ".join(temp_list).strip()
+            temp_attribute = "_".join(temp_list).strip()
             if current_target in ["self", "allies"]:
                 for curr_adv in target_list:
                     curr_adv.pop_boostCheckAlliesAdv(is_buff, temp_attribute)
@@ -1310,7 +1310,6 @@ def counter(
     # take the avg
     # loop through and take the avg
     for adv in adv_list:
-
         temp_adv_counter = adv.adventurerCounter
         temp_extra_boost = 1.0
         if adv.adventurerCounter.extraBoost != None:
@@ -1348,7 +1347,6 @@ def counters(
     counterRate: float,
     logs: Dict[str, List[str]],
 ) -> int:
-
     ret = interpretInstantEffects(
         assist_list, adv_list, enemy, memboost, counterRate, logs
     )

--- a/DanMemoDiscordBot/commands/calculatorUtil.py
+++ b/DanMemoDiscordBot/commands/calculatorUtil.py
@@ -692,45 +692,26 @@ def interpretExtraBoost(skillEffect, adventurer: "Adventurer", enemy: "Enemy") -
         temp_list.remove("skill")
     except:
         pass
-    target = temp_list[0]
+
+    if temp_list[0] == "self":
+        effect_lists = [adventurer.boostCheckAlliesAdv, adventurer.boostCheckAlliesAst]
+    else:
+        effect_lists = [enemy.boostCheckEnemyAdv, enemy.boostCheckEnemyAst]
     temp_list = temp_list[1:]
     attribute = "_".join(temp_list[: len(temp_list) - 1])
     attribute_type = temp_list[-1]
 
-    if target == "self":
-        # boostCheckAlliesAdv
-        for selfBuffsAdv in adventurer.boostCheckAlliesAdv:
-            if selfBuffsAdv.get("isbuff") == (attribute_type == "buff"):
-                if selfBuffsAdv.get("attribute") == attribute:
-                    extra_boosts_modifier_value = (
-                        extra_boosts_modifier_value
-                        + int(skillEffect.modifier.strip()) / 100
-                    )
-        # boostCheckAlliesAst
-        for selfBuffsAst in adventurer.boostCheckAlliesAst:
-            if selfBuffsAst.get("isbuff") == (attribute_type == "buff"):
-                if selfBuffsAst.get("attribute") == attribute:
-                    extra_boosts_modifier_value = (
-                        extra_boosts_modifier_value
-                        + int(skillEffect.modifier.strip()) / 100
-                    )
-    # target aka foes/foe
-    else:
-        for selfBuffsAdv in enemy.boostCheckEnemyAdv:
-            if selfBuffsAdv.get("isbuff") == (attribute_type == "buff"):
-                if selfBuffsAdv.get("attribute") == attribute:
-                    extra_boosts_modifier_value = (
-                        extra_boosts_modifier_value
-                        + int(skillEffect.modifier.strip()) / 100
-                    )
-        # boostCheckAlliesAst
-        for selfBuffsAst in enemy.boostCheckEnemyAst:
-            if selfBuffsAst.get("isbuff") == (attribute_type == "buff"):
-                if selfBuffsAst.get("attribute") == attribute:
-                    extra_boosts_modifier_value = (
-                        extra_boosts_modifier_value
-                        + int(skillEffect.modifier.strip()) / 100
-                    )
+    # adventurer effects
+    for selfBuffsAdv in effect_lists[0]:
+        if selfBuffsAdv.get("isbuff") == (attribute_type == "buff"):
+            if selfBuffsAdv.get("attribute") == attribute:
+                extra_boosts_modifier_value += int(skillEffect.modifier.strip()) / 100
+    # assist effects
+    for selfBuffsAst in effect_lists[1]:
+        if selfBuffsAst.get("isbuff") == (attribute_type == "buff"):
+            if selfBuffsAst.get("attribute") == attribute:
+                extra_boosts_modifier_value += int(skillEffect.modifier.strip()) / 100
+
     print(extra_boosts_modifier_value)
     return extra_boosts_modifier_value
 

--- a/DanMemoDiscordBot/commands/entities/adventurer.py
+++ b/DanMemoDiscordBot/commands/entities/adventurer.py
@@ -215,7 +215,7 @@ class Adventurer:
     def clearBuffs(self):
         # take the list but all the buffs with True is removed (keep all  the isbuff==False)
         self.boostCheckAlliesAdv = [
-            item for item in self.boostCheckAlliesAdv if item.get("isbuff") == False
+            item for item in self.boostCheckAlliesAdv if (item.get("isbuff") == False or "regen" in item.get("attribute"))
         ]
 
     def clearDebuffs(self):
@@ -238,12 +238,14 @@ class Adventurer:
                 else:
                     self.statsBoostAdv[attribute] = 0
 
-    def ExtendReduceBuffs(self, turns):
+    def ExtendReduceBuffs(self, turns, turnCountdown=False):
         for buffsDebuffs in self.boostCheckAlliesAdv:
             if buffsDebuffs.get("isbuff") == True and isinstance(
                 buffsDebuffs.get("duration"), int
             ):
-                buffsDebuffs["duration"] += turns
+                # Don't change duration of regen effects, unless it's the end-of-turn countdown
+                if "regen" not in buffsDebuffs.get("attribute") or turnCountdown:
+                    buffsDebuffs["duration"] += turns
         temp_expiry = [
             item
             for item in self.boostCheckAlliesAdv

--- a/DanMemoDiscordBot/commands/entities/adventurer.py
+++ b/DanMemoDiscordBot/commands/entities/adventurer.py
@@ -200,22 +200,23 @@ class Adventurer:
 
     def set_additionals(self, additional_count: int, origin_name: str):
         # only change/refresh if
-        # - the current additional action is already empty, or
-        # - the same additional is added, meaning it'll just be refreshed
-        # - the new addtional comes from the SA, overriding any non-SA additionals
+        # - the new additional has more actions than are left, refreshing+overriding the current one
+        # - or the new addtional comes from the SA, overriding any non-SA additionals
         if (
-            self.additionalCount == 0
-            or origin_name == self.additionalName
+            additional_count > self.additionalCount
             or origin_name == (self.get_specialSkill())[0]
         ):
             self.additionalCount = additional_count
             self.additionalName = origin_name
-        # else: SA additional is active and the newly activated is non-SA, which must not override so nothing happens
+        # else: SA additional is active and the newly activated is non-SA with at most
+        # as many actions as remain on the SA, which must not override so nothing happens
 
     def clearBuffs(self):
         # take the list but all the buffs with True is removed (keep all  the isbuff==False)
         self.boostCheckAlliesAdv = [
-            item for item in self.boostCheckAlliesAdv if (item.get("isbuff") == False or "regen" in item.get("attribute"))
+            item
+            for item in self.boostCheckAlliesAdv
+            if (item.get("isbuff") == False or "regen" in item.get("attribute"))
         ]
 
     def clearDebuffs(self):
@@ -337,5 +338,9 @@ class Adventurer:
                     attribute,
                     buffsdebuffs.get("duration"),
                 )
+            )
+        if self.additionalCount > 0:
+            ret.append(
+                f"Additional Actions: {self.additionalName}, {self.additionalCount} left"
             )
         return ret

--- a/DanMemoDiscordBot/commands/recordbuster/recordBusterCalc.py
+++ b/DanMemoDiscordBot/commands/recordbuster/recordBusterCalc.py
@@ -810,7 +810,7 @@ async def run(
                 # allies tick down status buffs
                 for active_adv in active_advs:
                     active_adv.ExtendReduceDebuffs(-1)
-                    active_adv.ExtendReduceBuffs(-1)
+                    active_adv.ExtendReduceBuffs(-1, turnCountdown=True)
                 # enemy statuses tick down
                 enemy.ExtendReduceDebuffs(-1)
                 enemy.ExtendReduceBuffs(-1)

--- a/DanMemoDiscordBot/database/terms/human_readable.json
+++ b/DanMemoDiscordBot/database/terms/human_readable.json
@@ -275,7 +275,9 @@
 	"per_each_target_taunt_debuff": "only when a target is inflicted with Taunt",
 	"per_each_target_poison_debuff": "only when a target is inflicted with Poison",
 	"per_each_target_charm_debuff": "only when a target is inflicted with Charm",
-	"per_each_self_hp_regen_buff": "per each [Self] HP Regen Skill",
+	"per_each_self_hp_regen_buff": "per each [Self] HP Regen Effect",
+	"per_each_self_mp_regen_buff": "per each [Self] MP Regen Effect",
+	"per_each_self_regen_buff": "per each [Self] Regen Effect",
 	"per_each_target_hp_regen_buff": "per each Target's HP Regen Skill",
 	"per_each_self_sa_gauge_charge_buff": "per each [Self] S.A Gauge Charge Buff effect", 
 


### PR DESCRIPTION
- Allow "per each regen" as a shorthand for "per each hp regen" and "per each mp regen" 
- Don't extend or remove regen skills through RB boss effects and regular skills
- Make regular skill additional actions override SA additional actions when number of SA actions left is less than the number of actions on the regular skill. This reflects what happens in-game.
- Prevent regular additionals from being used instead of SA additionals on a turn where regular additionals replace SA additionals running out that turn
- Fix buff/debuff removal skills to work properly on multi-word attributes (e.g. magic_resist)

Do some minor refactoring and formatting fixes in RB calc related files